### PR TITLE
Make rust example work on nixos 16.09

### DIFF
--- a/rust-programs/helloRust.nix
+++ b/rust-programs/helloRust.nix
@@ -1,4 +1,4 @@
-{ stdenv, rustPlatform, cargo }:
+{ stdenv, cargo, rustc }:
 
 stdenv.mkDerivation rec {
 
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
 
   src = ./hello;
 
-  buildInputs = [ rustPlatform.rustc cargo ];
+  buildInputs = [ rustc cargo ];
 
   buildPhase = ''
     cargo build --release


### PR DESCRIPTION
I am a nixos newbie so I might have missed something obvious but the unchanged code did not work for me. This works.